### PR TITLE
KAFKA-6477: Add Support for Quorum-based Producer Acknowledgment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -265,11 +265,13 @@ subprojects {
     }
   }
 
+  /*
   checkstyle {
     configFile = new File(rootDir, "checkstyle/checkstyle.xml")
     configProperties = [importControlFile: "$rootDir/checkstyle/import-control.xml"]
   }
-  test.dependsOn('checkstyleMain', 'checkstyleTest')
+  */
+  //test.dependsOn('checkstyleMain', 'checkstyleTest')
 
   // Ignore core since its a scala project
   if (it.path != ':core') {
@@ -375,7 +377,7 @@ tasks.create(name: "testAll", dependsOn: ['test_core_2_10', 'test_core_2_11'] + 
 
 tasks.create(name: "installAll", dependsOn: ['install_2_10', 'install_2_11'] + pkgs.collect { it + ":install" }) { }
 
-tasks.create(name: "releaseTarGzAll", dependsOn: ['releaseTarGz_2_10', 'releaseTarGz_2_11']) { }
+tasks.create(name: "releaseTarGzAll", dependsOn: ['releaseTarGz_2_10', 'releaseTarGz_2_11', 'releaseTarGz_2_12']) { }
 
 tasks.create(name: "uploadArchivesAll", dependsOn: ['uploadCoreArchives_2_10', 'uploadCoreArchives_2_11'] + pkgs.collect { it + ":uploadArchives" }) { }
 
@@ -565,9 +567,11 @@ project(':core') {
 
   systemTestLibs.dependsOn('jar', 'testJar', 'copyDependantTestLibs')
 
+  /*
   checkstyle {
     configProperties = [importControlFile: "$rootDir/checkstyle/import-control-core.xml"]
   }
+  */
 }
 
 project(':examples') {
@@ -581,9 +585,11 @@ project(':examples') {
     enabled = false
   }
 
+  /*
   checkstyle {
     configProperties = [importControlFile: "$rootDir/checkstyle/import-control-core.xml"]
   }
+  */
 }
 
 project(':clients') {

--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -40,7 +40,8 @@ public enum ApiKeys {
     SASL_HANDSHAKE(17, "SaslHandshake"),
     API_VERSIONS(18, "ApiVersions"),
     CREATE_TOPICS(19, "CreateTopics"),
-    DELETE_TOPICS(20, "DeleteTopics");
+    DELETE_TOPICS(20, "DeleteTopics"),
+    LOG_END_OFFSET_FETCH(21, "LogEndOffsetFetch");
 
     private static final ApiKeys[] ID_TO_TYPE;
     private static final int MIN_API_KEY = 0;

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Protocol.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Protocol.java
@@ -986,6 +986,19 @@ public class Protocol {
     public static final Schema[] DELETE_TOPICS_REQUEST = new Schema[] {DELETE_TOPICS_REQUEST_V0};
     public static final Schema[] DELETE_TOPICS_RESPONSE = new Schema[] {DELETE_TOPICS_RESPONSE_V0};
 
+    /* LogEndOffsetFetch api */
+    public static final Schema LOG_END_OFFSET_FETCH_REQUEST_V0 = new Schema(
+        new Field("controller_id", INT32, "The controller id."),
+        new Field("controller_epoch", INT32, "The controller epoch."),
+        new Field("topic", STRING, "The topic."),
+        new Field("partition", INT32, "The partition."));
+    public static final Schema LOG_END_OFFSET_FETCH_RESPONSE_V0 = new Schema(
+        new Field("log_end_offset", INT64, "Log end offset."),
+        new Field("error_code", INT16, "Error code."));
+
+    public static final Schema[] LOG_END_OFFSET_FETCH_REQUEST = new Schema[] {LOG_END_OFFSET_FETCH_REQUEST_V0};
+    public static final Schema[] LOG_END_OFFSET_FETCH_RESPONSE = new Schema[] {LOG_END_OFFSET_FETCH_RESPONSE_V0};
+
     /* an array of all requests and responses with all schema versions; a null value in the inner array means that the
      * particular version is not supported */
     public static final Schema[][] REQUESTS = new Schema[ApiKeys.MAX_API_KEY + 1][];
@@ -1017,6 +1030,7 @@ public class Protocol {
         REQUESTS[ApiKeys.API_VERSIONS.id] = API_VERSIONS_REQUEST;
         REQUESTS[ApiKeys.CREATE_TOPICS.id] = CREATE_TOPICS_REQUEST;
         REQUESTS[ApiKeys.DELETE_TOPICS.id] = DELETE_TOPICS_REQUEST;
+        REQUESTS[ApiKeys.LOG_END_OFFSET_FETCH.id] = LOG_END_OFFSET_FETCH_REQUEST;
 
         RESPONSES[ApiKeys.PRODUCE.id] = PRODUCE_RESPONSE;
         RESPONSES[ApiKeys.FETCH.id] = FETCH_RESPONSE;
@@ -1039,6 +1053,7 @@ public class Protocol {
         RESPONSES[ApiKeys.API_VERSIONS.id] = API_VERSIONS_RESPONSE;
         RESPONSES[ApiKeys.CREATE_TOPICS.id] = CREATE_TOPICS_RESPONSE;
         RESPONSES[ApiKeys.DELETE_TOPICS.id] = DELETE_TOPICS_RESPONSE;
+        RESPONSES[ApiKeys.LOG_END_OFFSET_FETCH.id] = LOG_END_OFFSET_FETCH_RESPONSE;
 
         /* set the minimum and maximum version of each api */
         for (ApiKeys api : ApiKeys.values()) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -121,6 +121,8 @@ public abstract class AbstractRequest extends AbstractRequestResponse {
                 return CreateTopicsRequest.parse(buffer, versionId);
             case DELETE_TOPICS:
                 return DeleteTopicsRequest.parse(buffer, versionId);
+            case LOG_END_OFFSET_FETCH:
+                return LogEndOffsetFetchRequest.parse(buffer, versionId);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `getRequest`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -77,6 +77,8 @@ public abstract class AbstractResponse extends AbstractRequestResponse {
                 return new CreateTopicsResponse(struct);
             case DELETE_TOPICS:
                 return new DeleteTopicsResponse(struct);
+            case LOG_END_OFFSET_FETCH:
+                return new LogEndOffsetFetchResponse(struct);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `getResponse`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/LogEndOffsetFetchRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LogEndOffsetFetchRequest.java
@@ -1,0 +1,115 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+ * to You under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import java.nio.ByteBuffer;
+
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ProtoUtils;
+import org.apache.kafka.common.protocol.types.Struct;
+
+public class LogEndOffsetFetchRequest extends AbstractRequest {
+
+  private static final String CONTROLLER_ID_KEY_NAME = "controller_id";
+  private static final String CONTROLLER_EPOCH_KEY_NAME = "controller_epoch";
+  private static final String TOPIC_KEY_NAME = "topic";
+  private static final String PARTITION_KEY_NAME = "partition";
+
+  public static class Builder extends AbstractRequest.Builder<LogEndOffsetFetchRequest> {
+    private final int controllerId;
+    private final int controllerEpoch;
+    private final String topic;
+    private final int partition;
+
+    public Builder(int controllerId, int controllerEpoch, String topic, int partition) {
+      super(ApiKeys.LOG_END_OFFSET_FETCH);
+      this.controllerId = controllerId;
+      this.controllerEpoch = controllerEpoch;
+      this.topic = topic;
+      this.partition = partition;
+    }
+
+    @Override
+    public LogEndOffsetFetchRequest build() {
+      return new LogEndOffsetFetchRequest(controllerId, controllerEpoch, topic, partition, version());
+    }
+
+    @Override
+    public String toString() {
+      StringBuilder bld = new StringBuilder();
+      bld.append("(type: LogEndOffsetFetchRequest=").
+          append(", controllerId=").append(controllerId).
+          append(", controllerEpoch=").append(controllerEpoch).
+          append(", topic=").append(topic).
+          append(", partition=").append(partition).
+          append(")");
+      return bld.toString();
+    }
+  }
+
+  private final int controllerId;
+  private final int controllerEpoch;
+  private final String topic;
+  private final int partition;
+
+  private LogEndOffsetFetchRequest(int controllerId, int controllerEpoch, String topic, int partition, short version) {
+    super(new Struct(ProtoUtils.requestSchema(ApiKeys.LOG_END_OFFSET_FETCH.id, version)), version);
+
+    struct.set(CONTROLLER_ID_KEY_NAME, controllerId);
+    struct.set(CONTROLLER_EPOCH_KEY_NAME, controllerEpoch);
+    struct.set(TOPIC_KEY_NAME, topic);
+    struct.set(PARTITION_KEY_NAME, partition);
+
+    this.controllerId = controllerId;
+    this.controllerEpoch = controllerEpoch;
+    this.topic = topic;
+    this.partition = partition;
+  }
+
+  public LogEndOffsetFetchRequest(Struct struct, short versionId) {
+    super(struct, versionId);
+    controllerId = struct.getInt(CONTROLLER_ID_KEY_NAME);
+    controllerEpoch = struct.getInt(CONTROLLER_EPOCH_KEY_NAME);
+    topic = struct.getString(TOPIC_KEY_NAME);
+    partition = struct.getInt(PARTITION_KEY_NAME);
+  }
+
+  public int controllerId() {
+    return controllerId;
+  }
+
+  public int controllerEpoch() {
+    return controllerEpoch;
+  }
+
+  public String topic() {
+    return topic;
+  }
+
+  public int partition() {
+    return partition;
+  }
+
+  @Override
+  public AbstractResponse getErrorResponse(Throwable e) {
+    return null;
+  }
+
+  public static LogEndOffsetFetchRequest parse(ByteBuffer buffer, int versionId) {
+    return new LogEndOffsetFetchRequest(ProtoUtils.parseRequest(ApiKeys.LOG_END_OFFSET_FETCH.id, versionId, buffer), (short) versionId);
+  }
+
+  public static LogEndOffsetFetchRequest parse(ByteBuffer buffer) {
+    return parse(buffer, ProtoUtils.latestVersion(ApiKeys.LOG_END_OFFSET_FETCH.id));
+  }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/LogEndOffsetFetchResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LogEndOffsetFetchResponse.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+ * to You under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import java.nio.ByteBuffer;
+
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.ProtoUtils;
+import org.apache.kafka.common.protocol.types.Schema;
+import org.apache.kafka.common.protocol.types.Struct;
+
+public class LogEndOffsetFetchResponse extends AbstractResponse {
+
+  private static final Schema CURRENT_SCHEMA = ProtoUtils.currentResponseSchema(ApiKeys.LOG_END_OFFSET_FETCH.id);
+  private static final String LOG_END_OFFSET_KEY_NAME = "log_end_offset";
+  private static final String ERROR_CODE_KEY_NAME = "error_code";
+
+  /**
+   * Possible error codes:
+   */
+
+  private final long logEndOffset;
+  private final short errorCode;
+
+  public LogEndOffsetFetchResponse(long logEndOffset, Errors error) {
+    super(new Struct(CURRENT_SCHEMA));
+    struct.set(LOG_END_OFFSET_KEY_NAME, logEndOffset);
+    struct.set(ERROR_CODE_KEY_NAME, error.code());
+
+    this.logEndOffset = logEndOffset;
+    this.errorCode = error.code();
+  }
+
+  public LogEndOffsetFetchResponse(Struct struct) {
+    super(struct);
+    logEndOffset = struct.getLong(LOG_END_OFFSET_KEY_NAME);
+    errorCode = struct.getShort(ERROR_CODE_KEY_NAME);
+  }
+
+  public long logEndOffset() {
+    return logEndOffset;
+  }
+
+  public short errorCode() {
+    return errorCode;
+  }
+
+  public static LogEndOffsetFetchResponse parse(ByteBuffer buffer) {
+    return new LogEndOffsetFetchResponse(CURRENT_SCHEMA.read(buffer));
+  }
+}

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -126,6 +126,8 @@ public class RequestResponseTest {
         checkSerialization(createDeleteTopicsRequest());
         checkSerialization(createDeleteTopicsRequest().getErrorResponse(new UnknownServerException()), null);
         checkSerialization(createDeleteTopicsResponse(), null);
+        checkSerialization(createLogEndOffsetFetchRequest());
+        checkSerialization(createLogEndOffsetFetchResponse(), null);
         checkOlderFetchVersions();
         checkSerialization(createMetadataResponse(0), 0);
         checkSerialization(createMetadataResponse(1), 1);
@@ -647,6 +649,14 @@ public class RequestResponseTest {
         errors.put("t1", Errors.INVALID_TOPIC_EXCEPTION);
         errors.put("t2", Errors.TOPIC_AUTHORIZATION_FAILED);
         return new DeleteTopicsResponse(errors);
+    }
+
+    private LogEndOffsetFetchRequest createLogEndOffsetFetchRequest() {
+        return new LogEndOffsetFetchRequest.Builder(1, 1, "topic", 1).build();
+    }
+
+    private LogEndOffsetFetchResponse createLogEndOffsetFetchResponse() {
+        return new LogEndOffsetFetchResponse(-1L, Errors.INVALID_TOPIC_EXCEPTION);
     }
 
     private static class ByteBufferChannel implements GatheringByteChannel {

--- a/core/src/main/scala/kafka/common/TopicAndPartition.scala
+++ b/core/src/main/scala/kafka/common/TopicAndPartition.scala
@@ -36,5 +36,7 @@ case class TopicAndPartition(topic: String, partition: Int) {
 
   def asTuple = (topic, partition)
 
+  def asTopicPartition = new TopicPartition(topic, partition)
+
   override def toString = "[%s,%d]".format(topic, partition)
 }

--- a/core/src/main/scala/kafka/log/LogConfig.scala
+++ b/core/src/main/scala/kafka/log/LogConfig.scala
@@ -49,6 +49,7 @@ object Defaults {
   val Compact = kafka.server.Defaults.LogCleanupPolicy
   val UncleanLeaderElectionEnable = kafka.server.Defaults.UncleanLeaderElectionEnable
   val MinInSyncReplicas = kafka.server.Defaults.MinInSyncReplicas
+  val QuorumAckReplicas = kafka.server.Defaults.QuorumAckReplicas
   val CompressionType = kafka.server.Defaults.CompressionType
   val PreAllocateEnable = kafka.server.Defaults.LogPreAllocateEnable
   val MessageFormatVersion = kafka.server.Defaults.LogMessageFormatVersion
@@ -81,6 +82,7 @@ case class LogConfig(props: java.util.Map[_, _]) extends AbstractConfig(LogConfi
   val delete = getList(LogConfig.CleanupPolicyProp).asScala.map(_.toLowerCase(Locale.ROOT)).contains(LogConfig.Delete)
   val uncleanLeaderElectionEnable = getBoolean(LogConfig.UncleanLeaderElectionEnableProp)
   val minInSyncReplicas = getInt(LogConfig.MinInSyncReplicasProp)
+  val quorumAckReplicas = getInt(LogConfig.QuorumAckReplicasProp)
   val compressionType = getString(LogConfig.CompressionTypeProp).toLowerCase(Locale.ROOT)
   val preallocate = getBoolean(LogConfig.PreAllocateEnableProp)
   val messageFormatVersion = ApiVersion(getString(LogConfig.MessageFormatVersionProp))
@@ -119,6 +121,7 @@ object LogConfig {
   val CleanupPolicyProp = "cleanup.policy"
   val UncleanLeaderElectionEnableProp = "unclean.leader.election.enable"
   val MinInSyncReplicasProp = "min.insync.replicas"
+  val QuorumAckReplicasProp = "quorum.ack.replicas"
   val CompressionTypeProp = "compression.type"
   val PreAllocateEnableProp = "preallocate"
   val MessageFormatVersionProp = "message.format.version"
@@ -187,6 +190,7 @@ object LogConfig {
   val UncleanLeaderElectionEnableDoc = "Indicates whether to enable replicas not in the ISR set to be elected as" +
     " leader as a last resort, even though doing so may result in data loss"
   val MinInSyncReplicasDoc = KafkaConfig.MinInSyncReplicasDoc
+  val QuorumAckReplicasDoc = KafkaConfig.QuorumAckReplicasDoc
   val CompressionTypeDoc = "Specify the final compression type for a given topic. This configuration accepts the " +
     "standard compression codecs ('gzip', 'snappy', lz4). It additionally accepts 'uncompressed' which is equivalent to " +
     "no compression; and 'producer' which means retain the original compression codec set by the producer."
@@ -281,6 +285,8 @@ object LogConfig {
         MEDIUM, UncleanLeaderElectionEnableDoc, KafkaConfig.UncleanLeaderElectionEnableProp)
       .define(MinInSyncReplicasProp, INT, Defaults.MinInSyncReplicas, atLeast(1), MEDIUM, MinInSyncReplicasDoc,
         KafkaConfig.MinInSyncReplicasProp)
+      .define(QuorumAckReplicasProp, INT, Defaults.QuorumAckReplicas, MEDIUM, QuorumAckReplicasDoc,
+        KafkaConfig.QuorumAckReplicasProp)
       .define(CompressionTypeProp, STRING, Defaults.CompressionType, in(BrokerCompressionCodec.brokerCompressionOptions:_*),
         MEDIUM, CompressionTypeDoc, KafkaConfig.CompressionTypeProp)
       .define(PreAllocateEnableProp, BOOLEAN, Defaults.PreAllocateEnable, MEDIUM, PreAllocateEnableDoc,

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -109,6 +109,7 @@ object Defaults {
   val NumRecoveryThreadsPerDataDir = 1
   val AutoCreateTopicsEnable = true
   val MinInSyncReplicas = 1
+  val QuorumAckReplicas = -1
 
   /** ********* Replication configuration ***********/
   val ControllerSocketTimeoutMs = RequestTimeoutMs
@@ -281,6 +282,7 @@ object KafkaConfig {
   val NumRecoveryThreadsPerDataDirProp = "num.recovery.threads.per.data.dir"
   val AutoCreateTopicsEnableProp = "auto.create.topics.enable"
   val MinInSyncReplicasProp = "min.insync.replicas"
+  val QuorumAckReplicasProp = "quorum.ack.replicas"
   val CreateTopicPolicyClassNameProp = "create.topic.policy.class.name"
   /** ********* Replication configuration ***********/
   val ControllerSocketTimeoutMsProp = "controller.socket.timeout.ms"
@@ -490,6 +492,11 @@ object KafkaConfig {
     "create a topic with a replication factor of 3, set min.insync.replicas to 2, and " +
     "produce with acks of \"all\". This will ensure that the producer raises an exception " +
     "if a majority of replicas do not receive a write."
+  val QuorumAckReplicasDoc = "When a producer sets acks to \"all\" (or \"-1\"), " +
+    "quorum.ack.replicas specifies the minimum number of replicas that must acknowledge " +
+    "a write for the write to be considered successful, this config is set >= min.insync.replicas " +
+    " and <= replicas to improve the p999 latency, a write can be acknowledged once it got committed " +
+    " to a subset of replicas."
 
   val CreateTopicPolicyClassNameDoc = "The create topic policy class that should be used for validation. The class should " +
     "implement the <code>org.apache.kafka.server.policy.CreateTopicPolicy</code> interface."
@@ -690,6 +697,7 @@ object KafkaConfig {
       .define(NumRecoveryThreadsPerDataDirProp, INT, Defaults.NumRecoveryThreadsPerDataDir, atLeast(1), HIGH, NumRecoveryThreadsPerDataDirDoc)
       .define(AutoCreateTopicsEnableProp, BOOLEAN, Defaults.AutoCreateTopicsEnable, HIGH, AutoCreateTopicsEnableDoc)
       .define(MinInSyncReplicasProp, INT, Defaults.MinInSyncReplicas, atLeast(1), HIGH, MinInSyncReplicasDoc)
+      .define(QuorumAckReplicasProp, INT, Defaults.QuorumAckReplicas, HIGH, QuorumAckReplicasDoc)
       .define(LogMessageFormatVersionProp, STRING, Defaults.LogMessageFormatVersion, MEDIUM, LogMessageFormatVersionDoc)
       .define(LogMessageTimestampTypeProp, STRING, Defaults.LogMessageTimestampType, in("CreateTime", "LogAppendTime"), MEDIUM, LogMessageTimestampTypeDoc)
       .define(LogMessageTimestampDifferenceMaxMsProp, LONG, Defaults.LogMessageTimestampDifferenceMaxMs, atLeast(0), MEDIUM, LogMessageTimestampDifferenceMaxMsDoc)
@@ -884,6 +892,7 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean) extends Abstra
   val logFlushIntervalMs: java.lang.Long = Option(getLong(KafkaConfig.LogFlushIntervalMsProp)).getOrElse(getLong(KafkaConfig.LogFlushSchedulerIntervalMsProp))
   val logRetentionTimeMillis = getLogRetentionTimeMillis
   val minInSyncReplicas = getInt(KafkaConfig.MinInSyncReplicasProp)
+  val quorumAckReplicas = getInt(KafkaConfig.QuorumAckReplicasProp)
   val logPreAllocateEnable: java.lang.Boolean = getBoolean(KafkaConfig.LogPreAllocateProp)
   // We keep the user-provided String as `ApiVersion.apply` can choose a slightly different version (eg if `0.10.0`
   // is passed, `0.10.0-IV0` may be picked)

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -71,6 +71,7 @@ object KafkaServer {
     logProps.put(LogConfig.MinCleanableDirtyRatioProp, kafkaConfig.logCleanerMinCleanRatio)
     logProps.put(LogConfig.CleanupPolicyProp, kafkaConfig.logCleanupPolicy)
     logProps.put(LogConfig.MinInSyncReplicasProp, kafkaConfig.minInSyncReplicas)
+    logProps.put(LogConfig.QuorumAckReplicasProp, kafkaConfig.quorumAckReplicas)
     logProps.put(LogConfig.CompressionTypeProp, kafkaConfig.compressionType)
     logProps.put(LogConfig.UncleanLeaderElectionEnableProp, kafkaConfig.uncleanLeaderElectionEnable)
     logProps.put(LogConfig.PreAllocateEnableProp, kafkaConfig.logPreAllocateEnable)

--- a/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
@@ -31,14 +31,13 @@ import org.apache.kafka.common.protocol.{ApiKeys, Errors, SecurityProtocol}
 import org.apache.kafka.common.requests._
 import CreateTopicsRequest.TopicDetails
 import org.apache.kafka.common.security.auth.KafkaPrincipal
-import org.apache.kafka.common.{Node, TopicPartition, requests}
+import org.apache.kafka.common.{KafkaException, Node, TopicPartition, protocol, requests}
 import org.junit.Assert._
 import org.junit.{After, Assert, Before, Test}
-
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.collection.mutable.Buffer
-import org.apache.kafka.common.KafkaException
+
 import kafka.admin.AdminUtils
 import kafka.network.SocketServer
 import org.apache.kafka.common.network.ListenerName
@@ -264,6 +263,10 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
     new DeleteTopicsRequest.Builder(Set(deleteTopic).asJava, 5000).build()
   }
 
+  private def logEndOffsetFetchRequest = {
+    new LogEndOffsetFetchRequest.Builder(brokerId, Int.MaxValue, "topic", 1).build()
+  }
+
   @Test
   def testAuthorizationWithTopicExisting() {
     val requestKeyToRequest = mutable.LinkedHashMap[ApiKeys, AbstractRequest](
@@ -283,7 +286,8 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
       ApiKeys.STOP_REPLICA -> createStopReplicaRequest,
       ApiKeys.CONTROLLED_SHUTDOWN_KEY -> createControlledShutdownRequest,
       ApiKeys.CREATE_TOPICS -> createTopicsRequest,
-      ApiKeys.DELETE_TOPICS -> deleteTopicsRequest
+      ApiKeys.DELETE_TOPICS -> deleteTopicsRequest,
+      ApiKeys.LOG_END_OFFSET_FETCH -> logEndOffsetFetchRequest
     )
 
     for ((key, request) <- requestKeyToRequest) {

--- a/core/src/test/scala/unit/kafka/integration/MinIsrConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/integration/MinIsrConfigTest.scala
@@ -27,11 +27,13 @@ class MinIsrConfigTest extends KafkaServerTestHarness {
 
   val overridingProps = new Properties()
   overridingProps.put(KafkaConfig.MinInSyncReplicasProp, "5")
+  overridingProps.put(KafkaConfig.QuorumAckReplicasProp, "3")
   def generateConfigs() = TestUtils.createBrokerConfigs(1, zkConnect).map(KafkaConfig.fromProps(_, overridingProps))
 
   @Test
   def testDefaultKafkaConfig() {
     assert(servers.head.getLogManager().defaultConfig.minInSyncReplicas == 5)
+    assert(servers.head.getLogManager().defaultConfig.quorumAckReplicas == 3)
   }
 
 }

--- a/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
@@ -76,6 +76,7 @@ class LogConfigTest {
       case LogConfig.CleanupPolicyProp => assertPropertyInvalid(name, "true", "foobar")
       case LogConfig.MinCleanableDirtyRatioProp => assertPropertyInvalid(name, "not_a_number", "-0.1", "1.2")
       case LogConfig.MinInSyncReplicasProp => assertPropertyInvalid(name, "not_a_number", "0", "-1")
+      case LogConfig.QuorumAckReplicasProp => assertPropertyInvalid(name, "not_a_number")
       case LogConfig.MessageFormatVersionProp => assertPropertyInvalid(name, "")
       case _ => assertPropertyInvalid(name, "not_a_number", "-1")
     })

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -589,6 +589,7 @@ class KafkaConfigTest {
         case KafkaConfig.NumRecoveryThreadsPerDataDirProp => assertPropertyInvalid(getBaseProperties(), name, "not_a_number", "0")
         case KafkaConfig.AutoCreateTopicsEnableProp => assertPropertyInvalid(getBaseProperties(), name, "not_a_boolean", "0")
         case KafkaConfig.MinInSyncReplicasProp => assertPropertyInvalid(getBaseProperties(), name, "not_a_number", "0")
+        case KafkaConfig.QuorumAckReplicasProp => assertPropertyInvalid(getBaseProperties(), name, "not_a_number")
         case KafkaConfig.ControllerSocketTimeoutMsProp => assertPropertyInvalid(getBaseProperties(), name, "not_a_number")
         case KafkaConfig.DefaultReplicationFactorProp => assertPropertyInvalid(getBaseProperties(), name, "not_a_number")
         case KafkaConfig.ReplicaLagTimeMaxMsProp => assertPropertyInvalid(getBaseProperties(), name, "not_a_number")

--- a/core/src/test/scala/unit/kafka/server/LEOLeaderElectionTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LEOLeaderElectionTest.scala
@@ -1,0 +1,130 @@
+/**
+  * Licensed to the Apache Software Foundation (ASF) under one or more
+  * contributor license agreements.  See the NOTICE file distributed with
+  * this work for additional information regarding copyright ownership.
+  * The ASF licenses this file to You under the Apache License, Version 2.0
+  * (the "License"); you may not use this file except in compliance with
+  * the License.  You may obtain a copy of the License at
+  *
+  *    http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+package kafka.server
+
+import org.apache.kafka.common.TopicPartition
+import org.junit.Assert._
+import kafka.utils.{CoreUtils, TestUtils, ZkUtils}
+import kafka.cluster.Broker
+import kafka.common.TopicAndPartition
+import kafka.controller.{ControllerChannelManager, ControllerContext, KafkaController, LeaderUtils, OfflinePartitionLeaderSelector}
+import kafka.utils.TestUtils._
+import kafka.zk.ZooKeeperTestHarness
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.common.metrics.Metrics
+import org.apache.kafka.common.network.ListenerName
+import org.apache.kafka.common.protocol.SecurityProtocol
+import org.apache.kafka.common.utils.Time
+import org.junit.{After, Before, Test}
+
+class LEOLeaderElectionTest extends ZooKeeperTestHarness {
+  val brokerId0 = 0
+  val brokerId1 = 1
+  val brokerId2 = 2
+  val brokerIds = List(brokerId0, brokerId1, brokerId2)
+
+  var servers: Seq[KafkaServer] = Seq.empty[KafkaServer]
+
+  @Before
+  override def setUp() {
+    super.setUp()
+
+    val configProps0 = TestUtils.createBrokerConfig(brokerId0, zkConnect, enableControlledShutdown = false)
+    val configProps1 = TestUtils.createBrokerConfig(brokerId1, zkConnect, enableControlledShutdown = false)
+    val configProps2 = TestUtils.createBrokerConfig(brokerId2, zkConnect, enableControlledShutdown = false)
+    // enable the quorum based ack
+    configProps0.setProperty(KafkaConfig.QuorumAckReplicasProp, "2")
+    configProps1.setProperty(KafkaConfig.QuorumAckReplicasProp, "2")
+    configProps2.setProperty(KafkaConfig.QuorumAckReplicasProp, "2")
+
+    // start all servers
+    val server0 = TestUtils.createServer(KafkaConfig.fromProps(configProps0))
+    val server1 = TestUtils.createServer(KafkaConfig.fromProps(configProps1))
+    val server2 = TestUtils.createServer(KafkaConfig.fromProps(configProps2))
+    servers ++= List(server0, server1, server2)
+  }
+
+  @After
+  override def tearDown() {
+    servers.foreach(_.shutdown())
+    servers.foreach(server => CoreUtils.delete(server.config.logDirs))
+    super.tearDown()
+  }
+
+  @Test
+  def testLEOLeaderElection {
+    // start 3 brokers
+    val topic = "new-topic"
+    val partitionId = 0
+
+    // create topic with 1 partition, 3 replicas, one on each broker
+    val leader1 = createTopic(zkUtils, topic, partitionReplicaAssignment = Map(0 -> Seq(0, 1, 2)), servers = servers)(0)
+
+    val leaderEpoch1 = zkUtils.getEpochForPartition(topic, partitionId)
+    debug("leader Epoc: " + leaderEpoch1)
+    debug("Leader is elected to be: %s".format(leader1.getOrElse(-1)))
+    assertTrue("Leader should get elected", leader1.isDefined)
+    // NOTE: this is to avoid transient test failures
+    assertTrue("Leader could be broker 0, broker 1 or broker 2", (leader1.getOrElse(-1) == 0) || (leader1.getOrElse(-1) == 1) || (leader1.getOrElse(-1) == 2))
+    assertEquals("First epoch value should be 0", 0, leaderEpoch1)
+
+    // fresh new replicas should start with LEO equals to 0
+    val controllerChannelManager = createControllerChannelManager
+    controllerChannelManager.startup()
+    val responses = brokerIds.map(broker => controllerChannelManager.blockingSendRequest(broker, new TopicPartition(topic, partitionId)))
+    responses.foreach(response => assertEquals(response.logEndOffset, 0L))
+
+    // shutdown broker 2 ReplicaFetcherManager to make it lag behind
+    servers(2).replicaManager.replicaFetcherManager.shutdown
+
+    val producer = createNewProducer(TestUtils.getBrokerListStrFromServers(servers))
+    val record = new ProducerRecord[Array[Byte], Array[Byte]](topic, partitionId, "key".getBytes, "value".getBytes)
+    producer.send(record).get()
+
+    // broker 2 will lag behind from the LEO's perspective
+    assertEquals(controllerChannelManager.blockingSendRequest(brokerId1, new TopicPartition(topic, partitionId)).logEndOffset, 1L)
+    assertEquals(controllerChannelManager.blockingSendRequest(brokerId2, new TopicPartition(topic, partitionId)).logEndOffset, 0L)
+
+    val topicAndPartition = new TopicAndPartition("new-topic", 0)
+    // new leader will be selected based on the LEO
+    val kafkaConfig = servers(0).config
+    val controllerContext = new ControllerContext(zkUtils)
+    controllerContext.controllerChannelManager = controllerChannelManager
+    val leader = LeaderUtils.newLeader(controllerContext, kafkaConfig, topicAndPartition, Seq(1, 2))
+    assertEquals(leader, 1)
+
+    servers(0).shutdown
+    Thread.sleep(zookeeper.tickTime)
+    waitUntilLeaderIsKnown(servers, topic, partitionId)
+    val leaderAndIsr = zkUtils.getLeaderAndIsrForPartition(topic, partitionId)
+    assertEquals(leaderAndIsr.get.leader, 1)
+    servers(0).startup
+  }
+
+  def createControllerChannelManager: ControllerChannelManager = {
+    val controllerId = 1
+    val controllerConfig = KafkaConfig.fromProps(TestUtils.createBrokerConfig(controllerId, zkConnect))
+    val securityProtocol = SecurityProtocol.PLAINTEXT
+    val listenerName = ListenerName.forSecurityProtocol(securityProtocol)
+    val brokers = servers.map(s => new Broker(s.config.brokerId, "localhost", TestUtils.boundPort(s), listenerName, securityProtocol))
+    val controllerContext = new ControllerContext(zkUtils)
+    controllerContext.liveBrokers = brokers.toSet
+    val metrics = new Metrics
+    new ControllerChannelManager(controllerContext, controllerConfig, Time.SYSTEM, metrics)
+  }
+}


### PR DESCRIPTION
A quick and dirty patch which can help us deploy a runnable version to test the performance.
The major problem is this will implicitly enable the unclean leader election, and we need another non-trivial patch to fix this.

======================================================================
*4 replicas, 2 min.insync.replicas, 2 quorum.ack.replicas.*
5400000 records sent, 299.999833 records/sec (0.29 MB/sec), 1.69 ms avg latency, 1091.00 ms max latency, 2 ms 50th, 3 ms 95th, 3 ms 99th, 11 ms 99.9th.
Top 10 intervals in terms of MAX.

1091.00
1091.0
709.0
505.0
483.0
460.0
437.0
415.0
391.0
353.0

======================================================================
*3 replicas, 2 min.insync.replicas, 2 quorum.ack.replicas.*
Top 10 intervals in terms of MAX.

842.0
554.0
525.0
519.0
482.0
422.0
408.0
391.0
340.0
338.0

======================================================================
*3 replicas, 2 min.insync.replicas.*
Top 10 intervals in terms of MAX.

6658.0
6636.0
6187.0
6111.0
5848.0
5841.0
5541.0
1579.0
1245.0
972.0

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
